### PR TITLE
DatasetResult objects now have property 'thredds_filecount' 

### DIFF
--- a/pyesgf/search/results.py
+++ b/pyesgf/search/results.py
@@ -154,6 +154,13 @@ class DatasetResult(BaseResult):
         #!TODO: should we decode this into a tuple?  self.json['id'].split('|')
         return self.json['id']
     
+    @property
+    def thredds_filecount(self):
+        """
+        Returns file count as reported by Thredds.
+        """
+        return self.json['number_of_files']
+
     def file_context(self):
         """
         Return a SearchContext for searching for files within this dataset.


### PR DESCRIPTION
Added property 'thredds_filecount' which is the value of 'number_of_files' from the json reply. This variable is useful to verify whether the filecount reported by Thredds tallies with the actual file count.  These numbers may not match up due to reasons such as not ignoring certain variables present in the datasets.
