### PR TITLE
shards handling in aggregation context

### DIFF
--- a/pyesgf/search/results.py
+++ b/pyesgf/search/results.py
@@ -77,7 +77,8 @@ class ResultSet(Sequence):
         query_dict = self.context._build_query()
         response = self.context.connection.send_search(query_dict, limit=limit, 
                                                        offset=offset,
-                                                       shards=self.context.shards)
+                                                       #shards=self.context.shards)
+                                                       shards=None)
         
         #!TODO: strip out results
         return response['response']['docs']


### PR DESCRIPTION
when you using distrib=True and aggregation context i got this exception:

raise EsgfSearchException('Shard %s is not available' % shard)

I'm using now the same handling as in file_context (results.py) and it works for me. Maybe you would like to integrate this patch on master branch.

Cheers
Carsten
